### PR TITLE
Add basic auth to Graph API

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,2 @@
+ADMIN_CREDENTIALS=Basic YWRtaW46cGFzc3dvcmTCow==
 EXPORT_MAILER_RECIPIENTS=first@email.com,second@email.com

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -27,6 +27,6 @@ class ApiController < ApplicationController
   end
 
   def parse_context
-    {}
+    { is_admin: request.headers['Authorization'] == ENV['ADMIN_CREDENTIALS'] }
   end
 end

--- a/scripts/encode-basic-auth
+++ b/scripts/encode-basic-auth
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+require 'base64'
+
+if ARGV.count != 2
+  puts 'usage: encode-basic-auth <username> <password>'
+  exit(-1)
+end
+
+username, password = ARGV
+credentials = Base64.encode64("#{username}:#{password}£")
+
+puts "Basic #{credentials}"

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -1,0 +1,41 @@
+describe ApiController do
+  describe '#execute' do
+    let(:env_credentials) { 'test-credentials' }
+    let(:credentials) { '' }
+
+    before do
+      allow(GraphSchema).to receive(:execute)
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('ADMIN_CREDENTIALS').and_return(env_credentials)
+
+      # rspec-rails is broke https://github.com/rspec/rspec-rails/issues/1655
+      request.headers['Authorization'] = credentials
+      post :execute, params: {}
+    end
+
+    context 'normally' do
+      it 'does not set the admin flag' do
+        expect(GraphSchema).to have_received(:execute)
+          .with(anything, hash_including(context: { is_admin: false }))
+      end
+    end
+
+    context 'with bad credentials' do
+      let(:credentials) { 'foo' }
+
+      it 'does not set the admin flag' do
+        expect(GraphSchema).to have_received(:execute)
+          .with(anything, hash_including(context: { is_admin: false }))
+      end
+    end
+
+    context 'with valid credentials' do
+      let(:credentials) { env_credentials }
+
+      it 'sets the admin flag' do
+        expect(GraphSchema).to have_received(:execute)
+          .with(anything, hash_including(context: { is_admin: true }))
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Set admin flag when basic auth check passes

Resolves #20.