### PR TITLE
Add total count to bills search

### DIFF
--- a/app/graphql/types/viewer_type.rb
+++ b/app/graphql/types/viewer_type.rb
@@ -46,7 +46,17 @@ module Types
       resolve -> (_obj, _args, _ctx) { Hearing.all }
     end
 
-    connection :bills, BillType.connection_type do
+    BillSearchConnectionType = BillType.define_connection do
+      name 'BillSearchConnection'
+
+      field :count do
+        description 'The total number of bills in the search results'
+        type !types.Int
+        resolve -> (obj, _args, _ctx) { obj.nodes.count }
+      end
+    end
+
+    connection :bills, BillSearchConnectionType do
       description 'All bills'
 
       argument :query, types.String, 'Returns bills whose title or summary match the query'

--- a/schema.json
+++ b/schema.json
@@ -280,7 +280,7 @@
               ],
               "type": {
                 "kind": "OBJECT",
-                "name": "BillConnection",
+                "name": "BillSearchConnection",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -1704,6 +1704,73 @@
                 "kind": "OBJECT",
                 "name": "Chamber",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "BillSearchConnection",
+          "description": "The connection type for Bill.",
+          "fields": [
+            {
+              "name": "count",
+              "description": "The total number of bills in the search results",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "BillEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/requests/bill_request_spec.rb
+++ b/spec/requests/bill_request_spec.rb
@@ -38,7 +38,8 @@ describe 'A bill request', graphql: :request do
     query = <<-eos
       query {
         viewer {
-          bills {
+          bills(first: 1) {
+            count
             edges {
               node {
                 id
@@ -52,7 +53,8 @@ describe 'A bill request', graphql: :request do
     body = request_graph_query(query)
     expect(body[:errors]).to be_blank
 
-    nodes = body.dig(:data, :viewer, :bills, :edges)
-    expect(nodes.length).to eq(2)
+    connection = body.dig(:data, :viewer, :bills)
+    expect(connection[:count]).to eq(2)
+    expect(connection[:edges].length).to eq(1)
   end
 end


### PR DESCRIPTION
Add `count` field to the `viewer.bills` connection

Resolves #35.