### PR TITLE
Install Honeybadger for error reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,13 @@ source 'https://rubygems.org'
 ruby '2.3.0'
 
 gem 'graphql'
+gem 'honeybadger'
 gem 'pg'
 gem 'pg_search'
 gem 'puma', '~> 3.0'
 gem 'rack-cors'
 gem 'rails', '~> 5.0.2'
 gem 'sidekiq'
-gem 'honeybadger'
 
 # scraping
 gem 'capybara'

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'puma', '~> 3.0'
 gem 'rack-cors'
 gem 'rails', '~> 5.0.2'
 gem 'sidekiq'
+gem 'honeybadger'
 
 # scraping
 gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
     graphiql-rails (1.4.1)
       rails
     graphql (1.5.3)
+    honeybadger (3.1.2)
     httparty (0.14.0)
       multi_xml (>= 0.5.2)
     i18n (0.8.1)
@@ -228,6 +229,7 @@ DEPENDENCIES
   faker
   graphiql-rails
   graphql
+  honeybadger
   httparty
   letter_opener_web
   listen (~> 3.0.5)
@@ -251,4 +253,4 @@ RUBY VERSION
    ruby 2.3.0p0
 
 BUNDLED WITH
-   1.14.6
+   1.15.1


### PR DESCRIPTION
Before deployment, the environment variable `HONEYBADGER_API_KEY` will need to be set on Heroku. The gem doesn't report errors in the development or test environments by default, so no configuration should be necessary in those environments.

Honeybadger can be [configured](http://docs.honeybadger.io/ruby/gem-reference/configuration.html) using either a YAML file or an initializer. I don't see any obvious need to change the defaults for now.