### PR TITLE
Fix ImportBillsJob bug

### DIFF
--- a/app/jobs/import_bills_job.rb
+++ b/app/jobs/import_bills_job.rb
@@ -12,7 +12,7 @@ class ImportBillsJob
     bill_attrs = @service
       .fetch_bills(fields: fields, updated_since: import_date)
       .map { |data| parse_attributes(data) }
-      .compact
+      .reject(&:nil?)
 
     bill_attrs.each do |attrs|
       bill = Bill.upsert_by!(:external_id, attrs)

--- a/spec/jobs/import_bills_job_spec.rb
+++ b/spec/jobs/import_bills_job_spec.rb
@@ -12,7 +12,7 @@ describe ImportBillsJob do
 
       allow(mock_redis).to receive(:get).with(:import_bills_job_date)
       allow(mock_redis).to receive(:set).with(:import_bills_job_date, anything)
-      allow(mock_service).to receive(:fetch_bills).and_return([])
+      allow(mock_service).to receive(:fetch_bills).and_return([].lazy)
 
       allow(ImportBillDetailsJob).to receive(:perform_async)
     end
@@ -63,7 +63,7 @@ describe ImportBillsJob do
           'sponsors' => []
         }
 
-        Array.wrap(base_response.merge(attrs))
+        Array.wrap(base_response.merge(attrs)).lazy
       end
 
       it "sets the bill's core attributes" do


### PR DESCRIPTION
* Use #reject instead of #compact, which is a method Enumerator::Lazy does not have
* Revise mock methods to return the correct type